### PR TITLE
Remove extra empty option for batch action list

### DIFF
--- a/Resources/views/CRUD/base_list_table_batch.html.twig
+++ b/Resources/views/CRUD/base_list_table_batch.html.twig
@@ -8,7 +8,6 @@
                 </label>
             </div>
             <select class='chosen-select show-tick span12' title='Choose one..' name='action'>
-                <option></option>
                 {% for action, options in batchactions %}
                     <option value='{{ action }}'>{{ options.label }}</option>
                 {% endfor %}


### PR DESCRIPTION
This causes exception when selected empty action is performed
